### PR TITLE
Fix the repo and issue URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "icon": "icon.png",
     "repository": {
         "type": "git",
-        "url": "https://github.com/iambibhas/vscode-django-snippets .git"
+        "url": "https://github.com/iambibhas/vscode-django-snippets.git"
     },
     "bugs": {
-        "url": "https://github.com/iambibhas/vscode-django-snippets /issues"
+        "url": "https://github.com/iambibhas/vscode-django-snippets/issues"
     },
 
     "engines": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "icon": "icon.png",
     "repository": {
         "type": "git",
-        "url": "https://github.com/iambibhas/vscode-django-snippets.git"
+        "url": "https://github.com/iambibhas/vscode-django-snippets"
     },
     "bugs": {
         "url": "https://github.com/iambibhas/vscode-django-snippets/issues"


### PR DESCRIPTION
When clicking on the package repository link in VSCode, it takes the browser to `https://github.com/iambibhas/vscode-django-snippets%20`, encoding the space into the URL. This change removes those spaces.